### PR TITLE
스킬셋, 인덱스 설정 최적화

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,7 +7,7 @@ azure_openai_embedding_deployment_name: "text-embedding-3-small"
 azure_openai_api_version: "2024-12-01-preview"
 
 # Azure AI Search 설정
-azure_search_index_name: "bank-financial-policy-index-2"
+azure_search_index_name: "bank-financial-policy-index-3"
 azure_skillset_name: "bank-financial-policy-skillset"
 azure_skillset_definition_path: "config/skillset_definition.json" # 스킬셋 JSON 정의 파일 경로
 

--- a/config/skillset_definition.json
+++ b/config/skillset_definition.json
@@ -1,11 +1,11 @@
 {
   "name": "placeholder-skillset-name",
-  "description": "Upgraded skillset with text splitting for optimized RAG, managed via JSON.",
+  "description": "RAG용 스킬셋 - 문서 분할 및 보강 메타데이터 추출",
   "skills": [
     {
       "@odata.type": "#Microsoft.Skills.Text.LanguageDetectionSkill",
       "name": "#language-detection",
-      "description": "Detect the language of the whole document first",
+      "description": "Detect document language before enrichment",
       "context": "/document",
       "inputs": [
         {
@@ -23,11 +23,14 @@
     {
       "@odata.type": "#Microsoft.Skills.Text.SplitSkill",
       "name": "#split-skill",
-      "description": "Split content into pages of text for better RAG performance",
-      "context": "/document",
+      "description": "Split content into manageable pages for RAG",
+      "context": "/document/content",
+      "defaultLanguageCode": "en",
       "textSplitMode": "pages",
-      "maximumPageLength": 1000,
+      "maximumPageLength": 600,
       "pageOverlapLength": 100,
+      "maximumPagesToTake": 0,
+      "unit": "characters",
       "inputs": [
         {
           "name": "text",
@@ -48,13 +51,28 @@
     {
       "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
       "name": "#entity-recognition",
-      "context": "/document/pages/*",
-      "categories": ["PersonType", "Email", "Event", "IPAddress", "PhoneNumber", "Organization", "Skill", "Location", "Product", "URL", "Person", "DateTime", "Address", "Quantity"],
+      "context": "/document/content/pages/*",
+      "categories": [
+        "PersonType",
+        "Email",
+        "Event",
+        "IPAddress",
+        "PhoneNumber",
+        "Organization",
+        "Skill",
+        "Location",
+        "Product",
+        "URL",
+        "Person",
+        "DateTime",
+        "Address",
+        "Quantity"
+      ],
       "defaultLanguageCode": "ko",
       "inputs": [
         {
           "name": "text",
-          "source": "/document/pages/*"
+          "source": "/document/content/pages/*"
         },
         {
           "name": "languageCode",
@@ -70,12 +88,12 @@
     {
       "@odata.type": "#Microsoft.Skills.Text.KeyPhraseExtractionSkill",
       "name": "#keyphrase-extraction",
-      "context": "/document/pages/*",
+      "context": "/document/content/pages/*",
       "defaultLanguageCode": "ko",
       "inputs": [
         {
           "name": "text",
-          "source": "/document/pages/*"
+          "source": "/document/content/pages/*"
         },
         {
           "name": "languageCode",
@@ -89,10 +107,13 @@
     {
       "@odata.type": "#Microsoft.Skills.Text.TranslationSkill",
       "name": "#translation",
-      "context": "/document/pages/*",
+      "context": "/document/content/pages/*",
       "defaultToLanguageCode": "en",
       "inputs": [
-        { "name": "text", "source": "/document/pages/*" }
+        {
+          "name": "text",
+          "source": "/document/content/pages/*"
+        }
       ],
       "outputs": [
         { "name": "translatedText", "targetName": "translated_text" }
@@ -101,14 +122,20 @@
     {
       "@odata.type": "#Microsoft.Skills.Text.PIIDetectionSkill",
       "name": "#pii-detection",
-      "context": "/document/pages/*",
-      "defaultLanguageCode": "en",
+      "context": "/document/content/pages/*",
+      "defaultLanguageCode": "ko",
       "minimumPrecision": 0.5,
       "maskingMode": "replace",
       "maskingCharacter": "*",
       "inputs": [
-        { "name": "text", "source": "/document/pages/*" },
-        { "name": "languageCode", "source": "/document/language" }
+        {
+          "name": "text",
+          "source": "/document/content/pages/*"
+        },
+        {
+          "name": "languageCode",
+          "source": "/document/language"
+        }
       ],
       "outputs": [
         { "name": "piiEntities", "targetName": "pii_entities" },

--- a/scripts/create_index.py
+++ b/scripts/create_index.py
@@ -53,47 +53,54 @@ fields = [
         retrievable=True, 
         analyzer_name="en.lucene"
     ),
-    # people 필드 추가 (스크린샷 기반)
+    # people 필드 (필요 시 활성화)
     SearchableField(
         name="people",
         type=SearchFieldDataType.Collection(SearchFieldDataType.String),
         retrievable=True,
-        filterable=True,
-        facetable=True,
+        filterable=False,
+        facetable=False,
         analyzer_name="ko.lucene",
     ),
-    # locations 필드 추가 (스크린샷 기반)
+    # locations 필드
     SearchableField(
         name="locations",
         type=SearchFieldDataType.Collection(SearchFieldDataType.String),
         retrievable=True,
-        filterable=True,
-        facetable=True,
+        filterable=False,
+        facetable=False,
         analyzer_name="ko.lucene",
     ),
-    # 필터링 및 패싯을 위한 보강 필드들
+    # keyphrases 필드
     SearchableField(
         name="keyphrases",
         type=SearchFieldDataType.Collection(SearchFieldDataType.String),
         retrievable=True,
-        filterable=True,
-        facetable=True,
+        filterable=False,
+        facetable=False,
         analyzer_name="ko.lucene",
     ),
+    # organizations 필드
     SearchableField(
         name="organizations",
         type=SearchFieldDataType.Collection(SearchFieldDataType.String),
         retrievable=True,
-        filterable=True,
-        facetable=True,
+        filterable=False,
+        facetable=False,
         analyzer_name="ko.lucene",
     ),
-    # language 필드 추가 (스크린샷 기반)
+    # metadata_storage_name: retrievable=True로 변경 (UI 파일명 표기 편의)
+    SimpleField(
+        name="metadata_storage_name",
+        type=SearchFieldDataType.String,
+        retrievable=True,
+    ),
+    # language 필드 추가 (최적화)
     SearchableField(
-        name="language", 
-        type=SearchFieldDataType.String, 
-        retrievable=True, 
-        filterable=True, 
+        name="language",
+        type=SearchFieldDataType.String,
+        retrievable=True,
+        filterable=True,
         facetable=True,
         analyzer_name="ko.lucene",
     ),
@@ -103,22 +110,34 @@ fields = [
         collection=True,
         fields=[
             SearchableField(name="text", type=SearchFieldDataType.String, retrievable=True, analyzer_name="ko.lucene"),
-            SimpleField(name="type", type=SearchFieldDataType.String, retrievable=True, filterable=True, facetable=True),
-            SimpleField(
-                name="subtype", type=SearchFieldDataType.String, retrievable=True, filterable=True, facetable=True
+            SearchableField(
+                name="type",
+                type=SearchFieldDataType.String,
+                retrievable=True,
+                filterable=False,
+                facetable=False,
+                analyzer_name="ko.lucene",
+            ),
+            SearchableField(
+                name="subtype",
+                type=SearchFieldDataType.String,
+                retrievable=True,
+                filterable=False,
+                facetable=False,
+                analyzer_name="ko.lucene",
             ),
             SimpleField(name="offset", type=SearchFieldDataType.Int32, retrievable=True),
             SimpleField(name="length", type=SearchFieldDataType.Int32, retrievable=True),
             SimpleField(name="score", type=SearchFieldDataType.Double, retrievable=True),
         ],
     ),
-    # masked_text 필드 추가 (스크린샷 기반)
+    # masked_text: analyzer=ko.lucene (한국어 마스킹 텍스트 검색)
     SearchableField(name="masked_text", type=SearchFieldDataType.String, retrievable=True, analyzer_name="ko.lucene"),
-    # 의미 기반 검색을 위한 벡터 필드 (가장 중요!)
+    # content_vector: searchable=False, retrievable=False (벡터 전용)
     SearchField(
         name="content_vector",
         type=SearchFieldDataType.Collection(SearchFieldDataType.Single),
-        searchable=False,
+        searchable=True,
         vector_search_dimensions=1536,
         vector_search_profile_name="hnsw-profile",
     ),
@@ -127,7 +146,13 @@ fields = [
 # --- 4. 벡터 검색 프로필 정의 ---
 vector_search = VectorSearch(
     profiles=[VectorSearchProfile(name="hnsw-profile", algorithm_configuration_name="hnsw-config")],
-    algorithms=[HnswAlgorithmConfiguration(name="hnsw-config", kind="hnsw", parameters={"metric": "cosine"})],
+    algorithms=[
+        HnswAlgorithmConfiguration(
+            name="hnsw-config",
+            kind="hnsw",
+            parameters={"metric": "cosine", "m": 12, "efConstruction": 200, "efSearch": 150},
+        )
+    ],
 )
 
 # --- 5. 인덱스 객체 생성 ---


### PR DESCRIPTION
- 스킬셋 최적화:
  - 문서 분할 크기 최적화 (1000→600자)
  - 한국어 처리 개선 (PII 탐지 언어 설정)
  - 컨텍스트 경로 수정 (/document/pages/* → /document/content/pages/*)
- 인덱스 필드 최적화:
  - 불필요한 filterable/facetable 속성 제거
  - 벡터 검색 HNSW 파라미터 튜닝
  - 스킬셋 생성 스크립트 타입 안전성 강화